### PR TITLE
Change Block Types to Work in JSON.stringify

### DIFF
--- a/ext2to3.user.js
+++ b/ext2to3.user.js
@@ -64,12 +64,12 @@
 
     function getBlockType (oldType) {
         switch (oldType) {
-            case ' ': return 'Scratch.BlockType.COMMAND';
-            case 'w': return 'Scratch.BlockType.COMMAND';
-            case 'r': return 'Scratch.BlockType.REPORTER';
-            case 'R': return 'Scratch.BlockType.REPORTER';
-            case 'b': return 'Scratch.BlockType.BOOLEAN';
-            case 'h': return 'Scratch.BlockType.HAT';
+            case ' ': return 'command';
+            case 'w': return 'command';
+            case 'r': return 'reporter';
+            case 'R': return 'reporter';
+            case 'b': return 'Boolean';
+            case 'h': return 'hat';
         }
     }
 


### PR DESCRIPTION
Because the info is transformed with JSON to a String, Scratch.BlockType.* gets turned into a string, which means it won't be loaded as the correct shape. See https://sheeptester.github.io/scratch-gui/?url=https://jamesbmadden.github.io/scratch-extensions/extension-converter-test.js. Scratch.BlockType.* are just strings anyway, so their values can be used instead.

See https://sheeptester.github.io/scratch-gui/?url=https://jamesbmadden.github.io/scratch-extensions/ext-converter-fixed.js for the working version with this fix.