### PR TITLE
Convert Functions to new Format

### DIFF
--- a/ext2to3.user.js
+++ b/ext2to3.user.js
@@ -49,6 +49,7 @@
             getInfo() {
                 return ${JSON.stringify(info)};
             }
+            ${convertFunctions(descriptor, ext)}
         }
         Scratch.extensions.register(new ${id}());`; // TODO: Add functions
         $(".box-content").css("text-align", "left");
@@ -90,6 +91,16 @@
             case '%n': fullArg = fullArg + " [" +letters[argValue]+ "]"; argValue++; break;
             case '%s': fullArg = fullArg + " [" +letters[argValue]+ "]"; argValue++; break;
         }
+    }
+
+    function convertFunctions (descriptor, ext) {
+      let functions = '';
+      descriptor.blocks.forEach((block, index) => {
+        let func = ext[block[2]]; // Get the function for the block
+        functions += func.toString().replace('function', block[2]); // Convert to string and replace the function prefix with the function name
+        // TODO: Change the arguments to the new behavior (probably involving the argument converter)
+      });
+      return functions;
     }
     // Your code here...
 })();


### PR DESCRIPTION
Currently doesn't work if the block has arguments, but for simple blocks it works.